### PR TITLE
Fixing error on tar.gz building script

### DIFF
--- a/devscripts/package.R
+++ b/devscripts/package.R
@@ -5,7 +5,7 @@ if(!("devtools" %in% installed.packages()[,"Package"]))
   install.packages("devtools")
 
 #devtools::install_deps()
-#devtools::document()
+devtools::document()
 # devtools::build_manual()
 # devtools::build_vignettes()
 


### PR DESCRIPTION
Fixing error on building script preventing documentation to being updated on tar.gz
No version update is needed